### PR TITLE
Allow sinatra dependency to go to 3.1.0

### DIFF
--- a/pmacs_refile.gemspec
+++ b/pmacs_refile.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.1.0"
 
   spec.add_dependency "rest-client", ">= 1.8", "< 3.0"
-  spec.add_dependency "sinatra", ">= 2.0.0", "<= 3.0.0"
+  spec.add_dependency "sinatra", ">= 2.0.0", "<= 3.1.0"
   spec.add_dependency "mime-types"
 end


### PR DESCRIPTION
There's a CVE for sinatra that is resolved in 3.0.4 and this restriction is keeping me from updating to a fixed version.